### PR TITLE
Use Alpine Linux and disable pip cache to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM python:3.6.1
+FROM python:3.6.1-alpine
 
-RUN pip install gixy
+RUN pip --no-cache-dir install gixy
 
 ENTRYPOINT ["gixy"]


### PR DESCRIPTION
Thanks for providing gixy in Docker! Here's some quick optimizations to reduce the image size.

```
$ docker build -t gixy:alpine .
...
Successfully built 556f7029b7c7
$ docker run --rm gixy:alpine --version
Gixy v0.1.4
$ docker images | head -3
REPOSITORY                                                     TAG                      IMAGE ID            CREATED             SIZE
gixy                                                           alpine                   556f7029b7c7        5 minutes ago       97.1 MB
anjuna/gixy                                                    latest                   80d7068f9fe0        2 days ago          697 MB
```